### PR TITLE
Add support for Spring Boot 3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
         <module>powerimo-jobs-boot2</module>
         <module>powerimo-jobs-starter-boot2</module>
         <module>powerimo-jobs-starter-boot3</module>
+        <module>powerimo-jobs-boot3</module>
     </modules>
 
     <properties>
@@ -25,7 +26,7 @@
         <slf4j.boot2.version>1.7.36</slf4j.boot2.version>
 
         <!-- Spring Boot 3 -->
-        <spring.boot3.version>3.2.0</spring.boot3.version>
+        <spring.boot3.version>3.1.2</spring.boot3.version>
         <slf4j.boot3.version>2.0.7</slf4j.boot3.version>
 
         <java.version>11</java.version>

--- a/powerimo-jobs-boot3/pom.xml
+++ b/powerimo-jobs-boot3/pom.xml
@@ -3,15 +3,19 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.powerimo</groupId>
+        <artifactId>powerimo-jobs</artifactId>
+        <version>0.3-SNAPSHOT</version>
+    </parent>
 
     <groupId>org.powerimo</groupId>
-    <artifactId>powerimo-jobs-starter-boot3</artifactId>
-    <version>${revision}</version>
-    <packaging>jar</packaging>
+    <artifactId>powerimo-jobs-boot3</artifactId>
 
     <properties>
         <revision>0.3-SNAPSHOT</revision>
-        <springboot3.version>3.2.0</springboot3.version>
+
+        <liquidbase.version>4.23.0</liquidbase.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -33,23 +37,42 @@
     <dependencies>
         <dependency>
             <groupId>org.powerimo</groupId>
-            <artifactId>powerimo-jobs-boot3</artifactId>
+            <artifactId>powerimo-jobs-core</artifactId>
             <version>${revision}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.powerimo</groupId>
-            <artifactId>powerimo-common</artifactId>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.boot3.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter</artifactId>
-            <version>${springboot3.version}</version>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <version>${spring.boot3.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <version>${spring.boot3.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+            <version>${liquidbase.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringDbStateRepository.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringDbStateRepository.java
@@ -1,0 +1,93 @@
+package org.powerimo.jobs.boot3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.powerimo.jobs.JobState;
+import org.powerimo.jobs.Status;
+import org.powerimo.jobs.StepState;
+import org.powerimo.jobs.base.AbstractPersistentStateRepository;
+import org.powerimo.jobs.boot3.entities.JobEntity;
+import org.powerimo.jobs.boot3.entities.StepEntity;
+import org.powerimo.jobs.boot3.repositories.JobRepository;
+import org.powerimo.jobs.boot3.repositories.StepRepository;
+import org.powerimo.jobs.exceptions.StateRepositoryException;
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.Optional;
+
+@RequiredArgsConstructor
+@Slf4j
+public class StdSpringDbStateRepository extends AbstractPersistentStateRepository {
+    private final JobRepository jobRepository;
+    private final StepRepository stepRepository;
+    private final Converter<JobEntity, JobState> jobEntityConverter;
+    private final Converter<StepEntity, StepState> stepEntityConverter;
+    private final Converter<JobState, JobEntity> jobStateConverter;
+    private final Converter<StepState, StepEntity> stepStateConverter;
+
+    @Override
+    public void updateJobState(JobState jobState) {
+        super.updateJobState(jobState);
+
+        if (jobState.getStatus() == Status.COMPLETED) {
+            getRunningJobStateList().remove(jobState);
+        }
+    }
+
+    @Override
+    public Optional<JobState> getPersistentJobState(String id) {
+        var entity = jobRepository.findById(id).orElse(null);
+        if (entity == null)
+            return Optional.empty();
+        return Optional.ofNullable(jobEntityConverter.convert(entity));
+    }
+
+    @Override
+    public Optional<StepState> getPersistentStepState(String id) {
+        var entity = stepRepository.findById(id).orElse(null);
+        if (entity == null)
+            return Optional.empty();
+        return Optional.ofNullable(stepEntityConverter.convert(entity));
+    }
+
+    @Override
+    public void addPersistentJobState(JobState jobState) {
+        var entity = jobStateConverter.convert(jobState);
+        if (entity == null) {
+            throw new StateRepositoryException("Converter returns empty entity");
+        }
+        jobRepository.save(entity);
+    }
+
+    @Override
+    public void updatePersistentJobState(JobState jobState) {
+        var entityOpt = jobRepository.findById(jobState.getId());
+        if (entityOpt.isEmpty()) {
+            throw new StateRepositoryException("Converter returns empty entity");
+        }
+        var entity = entityOpt.get();
+        entity.setResult(jobState.getJobResult().getResult());
+        entity.setResultMessage(jobState.getJobResult().getMessage());
+        entity.setCompletedAt(jobState.getCompletedAt());
+        entity.setStatus(jobState.getStatus());
+        jobRepository.save(entity);
+    }
+
+    @Override
+    public void addPersistentStepState(StepState stepState) {
+        var entity = stepStateConverter.convert(stepState);
+        if (entity == null) {
+            throw new StateRepositoryException("Converter returns empty entity");
+        }
+        stepRepository.save(entity);
+    }
+
+    @Override
+    public void updatePersistentStepState(StepState stepState) {
+        var entity = stepStateConverter.convert(stepState);
+        if (entity == null) {
+            throw new StateRepositoryException("Converter returns empty entity");
+        }
+        stepRepository.save(entity);
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringJob.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringJob.java
@@ -1,0 +1,32 @@
+package org.powerimo.jobs.boot3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.powerimo.jobs.Step;
+import org.powerimo.jobs.StepDescriptor;
+import org.powerimo.jobs.exceptions.RunnerException;
+import org.powerimo.jobs.std.StdJob;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
+@Component
+@Scope(value = "prototype")
+@RequiredArgsConstructor
+@Slf4j
+public class StdSpringJob extends StdJob {
+    private final ApplicationContext applicationContext;
+
+    @Override
+    protected Step createStep(StepDescriptor descriptor) throws RunnerException {
+        try {
+            return applicationContext.getBean(descriptor.getStepClass());
+        } catch (NoSuchBeanDefinitionException ex) {
+            log.info("No bean was found: " + descriptor.getStepClass() + "; Standard class will be used.");
+        }
+
+        // try to resolve to regular class
+        return super.createStep(descriptor);
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringRunner.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/StdSpringRunner.java
@@ -1,0 +1,19 @@
+package org.powerimo.jobs.boot3;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.powerimo.jobs.Job;
+import org.powerimo.jobs.JobDescriptor;
+import org.powerimo.jobs.std.StdRunner;
+import org.springframework.context.ApplicationContext;
+
+@Slf4j
+@RequiredArgsConstructor
+public class StdSpringRunner extends StdRunner {
+    private final ApplicationContext applicationContext;
+
+    @Override
+    protected Job createJob(JobDescriptor descriptor) {
+        return applicationContext.getBean(descriptor.getJobClass());
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/entities/JobEntity.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/entities/JobEntity.java
@@ -1,0 +1,40 @@
+package org.powerimo.jobs.boot3.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.powerimo.jobs.Result;
+import org.powerimo.jobs.Status;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Entity
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "powerimo_job")
+public class JobEntity {
+    @Id
+    private String id;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Instant startedAt;
+    private Instant completedAt;
+    private String code;
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private Result result;
+    private String resultMessage;
+
+    @Column(name = "job_parameters")
+    private String parameters;
+
+    @Column(name = "job_parameters_class")
+    private String parametersClass;
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/entities/StepEntity.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/entities/StepEntity.java
@@ -1,0 +1,38 @@
+package org.powerimo.jobs.boot3.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.powerimo.jobs.Result;
+import org.powerimo.jobs.Status;
+
+import jakarta.persistence.*;
+import java.time.Instant;
+
+@Data
+@Entity
+@Table(name = "powerimo_job_step")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StepEntity {
+    @Id
+    private String id;
+    private String jobId;
+    private Instant startedAt;
+    private Instant completedAt;
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private String code;
+    private int stepOrder;
+
+    @Enumerated(EnumType.STRING)
+    private Result result;
+
+    private String resultMessage;
+    private Integer countTotal;
+    private Integer countError;
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/JobEntityConverter.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/JobEntityConverter.java
@@ -1,0 +1,41 @@
+package org.powerimo.jobs.boot3.mappers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.Setter;
+import org.powerimo.jobs.JobState;
+import org.powerimo.jobs.boot3.entities.JobEntity;
+import org.powerimo.jobs.std.StdJobResult;
+import org.powerimo.jobs.std.StdJobState;
+import org.springframework.core.convert.converter.Converter;
+
+public class JobEntityConverter implements Converter<JobEntity, JobState> {
+    @Getter
+    @Setter
+    private ObjectMapper objectMapper;
+
+    public JobEntityConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public JobEntityConverter() {
+        this.objectMapper = new ObjectMapper();
+    }
+
+    @Override
+    public StdJobState convert(JobEntity source) {
+        return StdJobState.builder()
+                .id(source.getId())
+                .status(source.getStatus())
+                .startedAt(source.getStartedAt())
+                .completedAt(source.getCompletedAt())
+                .title(source.getTitle())
+                .status(source.getStatus())
+                .jobResult(
+                        StdJobResult.builder()
+                                .result(source.getResult())
+                                .message(source.getResultMessage())
+                        .build())
+                .build();
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/JobStateConverter.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/JobStateConverter.java
@@ -1,0 +1,61 @@
+package org.powerimo.jobs.boot3.mappers;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import org.powerimo.jobs.*;
+import org.powerimo.jobs.boot3.entities.JobEntity;
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class JobStateConverter implements Converter<JobState, JobEntity> {
+    @Getter
+    @Setter
+    private ObjectMapper objectMapper;
+
+    public JobStateConverter(ObjectMapper mapper) {
+        this.objectMapper = mapper;
+    }
+
+    public JobStateConverter() {
+        this.objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+    }
+
+    @SneakyThrows
+    @Override
+    public JobEntity convert(JobState source) {
+        var parameterText = serializeParameters(source.getArguments());
+
+        return JobEntity.builder()
+                .id(source.getId())
+                .title(source.getTitle())
+                .code(source.getJobDescriptor().getCode())
+                .startedAt(source.getStartedAt())
+                .completedAt(source.getCompletedAt())
+                .status(source.getStatus())
+                .resultMessage(source.getJobResult().getMessage())
+                .result(source.getJobResult().getResult())
+                .parameters(parameterText)
+                .build();
+    }
+
+    private String serializeParameters(List<Object> list) throws JsonProcessingException {
+        var filteredList = list.stream()
+                .filter(JobStateConverter::isSerializableParameter)
+                .collect(Collectors.toList());
+        return objectMapper.writeValueAsString(filteredList);
+    }
+
+    private static boolean isSerializableParameter(Object o) {
+        return !o.getClass().isAssignableFrom(JobContext.class)
+                && !(o.getClass().isAssignableFrom(JobState.class)
+                && !(o.getClass().isAssignableFrom(StepState.class))
+                && !o.getClass().isAssignableFrom(Job.class)
+                && !o.getClass().isAssignableFrom(Step.class));
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/StepEntityConverter.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/StepEntityConverter.java
@@ -1,0 +1,21 @@
+package org.powerimo.jobs.boot3.mappers;
+
+import org.powerimo.jobs.boot3.entities.StepEntity;
+import org.powerimo.jobs.StepState;
+import org.powerimo.jobs.std.StdStepState;
+import org.springframework.core.convert.converter.Converter;
+
+public class StepEntityConverter implements Converter<StepEntity, StepState> {
+
+    @Override
+    public StdStepState convert(StepEntity source) {
+        return StdStepState.builder()
+                .jobId(source.getJobId())
+                .id(source.getId())
+                .status(source.getStatus())
+                .startedAt(source.getStartedAt())
+                .completedAt(source.getCompletedAt())
+                .build();
+    }
+
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/StepStateConverter.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/mappers/StepStateConverter.java
@@ -1,0 +1,31 @@
+package org.powerimo.jobs.boot3.mappers;
+
+import org.powerimo.jobs.boot3.entities.StepEntity;
+import org.powerimo.jobs.StepState;
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.Arrays;
+
+public class StepStateConverter implements Converter<StepState, StepEntity> {
+
+    @Override
+    public StepEntity convert(StepState source) {
+        final String message = source.getStepResult().getCause() != null
+                ? source.getStepResult().getCause().getMessage() + "\n\n" + Arrays.toString(source.getStepResult().getCause().getStackTrace())
+                : source.getStepResult().getMessage();
+
+        return StepEntity.builder()
+                .id(source.getId())
+                .code(source.getStepDescriptor().getCode())
+                .jobId(source.getJobId())
+                .startedAt(source.getStartedAt())
+                .completedAt(source.getCompletedAt())
+                .status(source.getStatus())
+                .result(source.getStepResult().getResult())
+                .resultMessage(message)
+                .stepOrder(source.getStepDescriptor().getOrder())
+                .countError(Long.valueOf(source.getStepResult().getCountErrors()).intValue())
+                .countTotal(Long.valueOf(source.getStepResult().getCountTotal()).intValue())
+                .build();
+    }
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/repositories/JobRepository.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/repositories/JobRepository.java
@@ -1,0 +1,13 @@
+package org.powerimo.jobs.boot3.repositories;
+
+import org.powerimo.jobs.boot3.entities.JobEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.time.Instant;
+import java.util.List;
+
+public interface JobRepository extends CrudRepository<JobEntity, String> {
+    List<JobEntity> findAllByCodeOrderByStartedAtDesc(String code);
+    List<JobEntity> findAllByStartedAtBetween(Instant minStartedAt, Instant maxStartedAt);
+    List<JobEntity> findAllByCompletedAtBetween(Instant minStartedAt, Instant maxStartedAt);
+}

--- a/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/repositories/StepRepository.java
+++ b/powerimo-jobs-boot3/src/main/java/org/powerimo/jobs/boot3/repositories/StepRepository.java
@@ -1,0 +1,14 @@
+package org.powerimo.jobs.boot3.repositories;
+
+import org.powerimo.jobs.Status;
+import org.powerimo.jobs.boot3.entities.StepEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StepRepository extends CrudRepository<StepEntity, String> {
+    List<StepEntity> findAllByJobIdOrderByStartedAt(String jobId);
+    List<StepEntity> findAllByJobIdOrderByStartedAtDesc(String jobId);
+    Optional<StepEntity> findFirstByJobIdAndStatus(String jobId, Status status);
+}

--- a/powerimo-jobs-starter-boot3/src/main/java/org/powerimo/jobs/boot3/PowerimoJobsBoot3AutoConfiguration.java
+++ b/powerimo-jobs-starter-boot3/src/main/java/org/powerimo/jobs/boot3/PowerimoJobsBoot3AutoConfiguration.java
@@ -1,0 +1,90 @@
+package org.powerimo.jobs.boot3;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.powerimo.jobs.DescriptorRepository;
+import org.powerimo.jobs.Runner;
+import org.powerimo.jobs.RunnerConfiguration;
+import org.powerimo.jobs.StateRepository;
+import org.powerimo.jobs.boot3.mappers.JobEntityConverter;
+import org.powerimo.jobs.boot3.mappers.JobStateConverter;
+import org.powerimo.jobs.boot3.mappers.StepEntityConverter;
+import org.powerimo.jobs.boot3.mappers.StepStateConverter;
+import org.powerimo.jobs.boot3.repositories.JobRepository;
+import org.powerimo.jobs.boot3.repositories.StepRepository;
+import org.powerimo.jobs.std.StdDescriptorRepository;
+import org.powerimo.jobs.std.StdRunnerConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.repository.Repository;
+
+import jakarta.persistence.EntityManager;
+
+@Configuration
+@ConditionalOnClass({EntityManager.class, Repository.class})
+@EnableJpaRepositories(basePackages = {"org.powerimo.jobs.boot3.repositories"})
+@EntityScan(basePackages = {"org.powerimo.jobs.boot3.entities"})
+@ComponentScan(basePackages = {"org.powerimo.jobs.boot3"})
+public class PowerimoJobsBoot3AutoConfiguration {
+    private JobRepository jpaJobRepository;
+    private StepRepository jpaStepRepository;
+
+    @Autowired
+    public void setJpaJobRepository(JobRepository jpaJobRepository) {
+        this.jpaJobRepository = jpaJobRepository;
+    }
+
+    @Autowired
+    public void setJpaStepRepository(StepRepository jpaStepRepository) {
+        this.jpaStepRepository = jpaStepRepository;
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public ObjectMapper objectMapper() {
+        var mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        return mapper;
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public StateRepository stateRepository(ObjectMapper objectMapper) {
+        var jonEntityConverter = new JobEntityConverter(objectMapper);
+        var jobStateConverter = new JobStateConverter();
+        var stepEntityConverter = new StepEntityConverter();
+        var stepStateConverter = new StepStateConverter();
+        return new StdSpringDbStateRepository(jpaJobRepository, jpaStepRepository, jonEntityConverter, stepEntityConverter, jobStateConverter, stepStateConverter);
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public DescriptorRepository descriptorRepository() {
+        return new StdDescriptorRepository();
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public RunnerConfiguration runnerConfiguration(StateRepository stateRepository, DescriptorRepository descriptorRepository) {
+        return StdRunnerConfiguration.builder()
+                .createMissing(true)
+                .descriptorRepository(descriptorRepository)
+                .stateRepository(stateRepository)
+                .build();
+    }
+
+    @ConditionalOnMissingBean
+    @Bean
+    public Runner runner(RunnerConfiguration configuration, ApplicationContext applicationContext) {
+        var runner = new StdSpringRunner(applicationContext);
+        runner.setConfiguration(configuration);
+        return runner;
+    }
+
+}


### PR DESCRIPTION
Three new classes are introduced to support Spring Boot 3: StdSpringDbStateRepository, StdSpringJob and StdSpringRunner. Some new entities, repositories, and converter classes were created as part of the implementation, extending job processing functionality to work with Spring Boot 3. A module is added in the parent pom.xml file for powerimo-jobs-boot3 and the starter for Spring Boot 3 now includes this new module as a dependency.