### PR TITLE
Update pom.xml files for Spring Boot 3 Version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <slf4j.boot2.version>1.7.36</slf4j.boot2.version>
 
         <!-- Spring Boot 3 -->
-        <spring.boot3.version>3.1.2</spring.boot3.version>
+        <spring.boot3.version>3.2.0</spring.boot3.version>
         <slf4j.boot3.version>2.0.7</slf4j.boot3.version>
 
         <java.version>11</java.version>

--- a/powerimo-jobs-boot3/pom.xml
+++ b/powerimo-jobs-boot3/pom.xml
@@ -3,19 +3,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <parent>
-        <groupId>org.powerimo</groupId>
-        <artifactId>powerimo-jobs</artifactId>
-        <version>0.3-SNAPSHOT</version>
-    </parent>
 
     <groupId>org.powerimo</groupId>
     <artifactId>powerimo-jobs-boot3</artifactId>
+    <version>${revision}</version>
 
     <properties>
         <revision>0.3-SNAPSHOT</revision>
 
+        <springboot3.version>3.2.0</springboot3.version>
         <liquidbase.version>4.23.0</liquidbase.version>
+        <slf4j.boot3.version>2.0.7</slf4j.boot3.version>
 
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -59,12 +57,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
-            <version>${spring.boot3.version}</version>
+            <version>${springboot3.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
-            <version>${spring.boot3.version}</version>
+            <version>${springboot3.version}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
The commit updates the `pom.xml` files for both `powerimo-jobs-boot3` and the parent module. Spring Boot 3 version has been upgraded to 3.2.0. Also, the 'version' tag in the `powerimo-jobs-boot3` module is now set dynamically to `${revision}`. In addition, properties for `springboot3.version` and `slf4j.boot3.version` are added to the respective pom.xml.