### PR TITLE
Upgrade OpenJDK version in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,7 @@ pipeline {
 
     tools{
         maven 'maven3'
-        jdk 'OpenJDK11'
+        jdk 'OpenJDK17'
     }
 
     agent any


### PR DESCRIPTION
The OpenJDK version used in the Jenkinsfile has been updated from 'OpenJDK11' to 'OpenJDK17'. This change impacts the JDK tool specified for Jenkins builds, aligning it with the requirements of the latest project updates.