### PR TITLE
Upgrade OpenJDK version in Jenkinsfile

### DIFF
--- a/powerimo-jobs-boot3/pom.xml
+++ b/powerimo-jobs-boot3/pom.xml
@@ -80,4 +80,24 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>maven-group</id>
+            <url>https://nexus3.andewil.com/repository/maven-releases/</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <name>NexusReleases</name>
+            <url>https://nexus3.andewil.com/repository/maven-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <name>NexusSnapshots</name>
+            <url>https://nexus3.andewil.com/repository/maven-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>

--- a/powerimo-jobs-starter-boot3/pom.xml
+++ b/powerimo-jobs-starter-boot3/pom.xml
@@ -59,4 +59,24 @@
         </dependency>
     </dependencies>
 
+    <repositories>
+        <repository>
+            <id>maven-group</id>
+            <url>https://nexus3.andewil.com/repository/maven-releases/</url>
+        </repository>
+    </repositories>
+
+    <distributionManagement>
+        <repository>
+            <id>nexus-releases</id>
+            <name>NexusReleases</name>
+            <url>https://nexus3.andewil.com/repository/maven-releases</url>
+        </repository>
+        <snapshotRepository>
+            <id>nexus-snapshots</id>
+            <name>NexusSnapshots</name>
+            <url>https://nexus3.andewil.com/repository/maven-snapshots</url>
+        </snapshotRepository>
+    </distributionManagement>
+
 </project>


### PR DESCRIPTION
The OpenJDK version used in the Jenkinsfile has been updated from 'OpenJDK11' to 'OpenJDK17'. This change impacts the JDK tool specified for Jenkins builds, aligning it with the requirements of the latest project updates.