### PR TITLE
Add autoconfiguration for jobs starter boot3

### DIFF
--- a/powerimo-jobs-starter-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/powerimo-jobs-starter-boot3/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+org.powerimo.jobs.boot3.PowerimoJobsBoot3AutoConfiguration


### PR DESCRIPTION
An autoconfiguration was added for the PowerimoJobsBoot3. This is represented in the AutoConfiguration import file under resources in the powerimo-jobs-starter-boot3 project. The addition will allow the application to automatically configure itself based on the project settings.